### PR TITLE
Fix testimonial interpolation bug

### DIFF
--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -74,7 +74,7 @@ const Testimonials = () => {
             </div>
             
             <p className="mb-8 text-lg italic text-alaula-dark/90">
-              "{testimonials[activeIndex].content}"
+              &ldquo;{testimonials[activeIndex].content}&rdquo;
             </p>
             
             <div className="flex items-center">


### PR DESCRIPTION
## Summary
- fix quotes around testimonial content so the string renders correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684033c03dac8322914a778c67f6182d