### PR TITLE
Fix README tech list intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm run dev
 
 ## What technologies are used for this project?
 
-This project is built with .
+This project is built with:
 
 - Vite
 - TypeScript


### PR DESCRIPTION
## Summary
- fix the introductory line before the technology list in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840377c70948322b893a67775a3bea7