### PR TITLE
Implement sidebar cookie reading

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -70,7 +70,18 @@ const SidebarProvider = React.forwardRef<
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(defaultOpen)
+    const [_open, _setOpen] = React.useState(() => {
+      // Read persisted sidebar state from a cookie if available.
+      if (typeof document !== "undefined") {
+        const match = document.cookie.match(
+          new RegExp(`(?:^|; )${SIDEBAR_COOKIE_NAME}=([^;]*)`)
+        )
+        if (match) {
+          return match[1] === "true"
+        }
+      }
+      return defaultOpen
+    })
     const open = openProp ?? _open
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {


### PR DESCRIPTION
## Summary
- restore sidebar open state from cookie in SidebarProvider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840377e0fd483229d4b8dc63e985854